### PR TITLE
Add settings modal for LLM instructions and cache clearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,9 @@
 
           <!-- Right-side actions -->
           <div class="flex items-center gap-2">
+            <button id="settings-btn" aria-label="Settings" class="grid h-9 w-9 place-items-center rounded-xl border border-neutral-300 bg-white text-sm hover:bg-neutral-50">
+              <i class="fa-solid fa-gear"></i>
+            </button>
             <button id="export-json" class="hidden sm:inline-flex items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3.5 h-9 text-sm hover:bg-neutral-50">
               <i class="fa-solid fa-download"></i><span>Export</span>
             </button>
@@ -131,6 +134,23 @@
       </div>
     </div>
   </footer>
+
+  <!-- Settings Modal -->
+  <div id="settings-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex h-full w-full items-center justify-center bg-black/50">
+      <div class="card w-96 bg-white p-6">
+        <h2 class="text-lg font-semibold mb-4">Settings</h2>
+        <label for="llm-instructions" class="block text-sm font-medium mb-1">Special instructions for LLM</label>
+        <textarea id="llm-instructions" rows="3" class="w-full rounded-lg border border-neutral-300 p-2 text-sm mb-4" placeholder="e.g., Answer with bullet points"></textarea>
+        <button id="clear-cache" class="w-full mb-4 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm hover:bg-neutral-50">Clear Cache</button>
+        <p class="text-xs text-neutral-500 mb-4">Future settings coming soon.</p>
+        <div class="flex justify-end gap-2">
+          <button id="settings-cancel" class="rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-sm hover:bg-neutral-50">Cancel</button>
+          <button id="settings-save" class="rounded-lg bg-[var(--osg-orange)] px-3 py-1.5 text-sm text-white hover:opacity-95">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <script>
     /* ===== PWA manifest (no extra file) ===== */
@@ -227,6 +247,8 @@
       const text = promptEl.value.trim();
       if(!text) return;
 
+      const instructions = localStorage.getItem('osg_instructions') || '';
+
       // Hide starters on first send
       starters.classList.add('hidden');
 
@@ -240,7 +262,7 @@
 
       // Fake thinking then respond based on mode
       const mode = document.querySelector('input[name="mode"]:checked').value;
-      const reply = mockAnswer(text, mode);
+      const reply = mockAnswer(text, mode, instructions);
       setTimeout(() => {
         pushMessage({role:'assistant', content:reply});
         renderBubble('assistant', reply, true);
@@ -283,7 +305,8 @@
       chat.appendChild(a);
     }
 
-    function mockAnswer(q, mode){
+    function mockAnswer(q, mode, instructions){
+      if(instructions) console.info('[LLM instructions]', instructions);
       if(mode==='sources_only'){
         return `<ul class='list-disc pl-5'><li>City Minutes • 2025‑08‑26</li><li>Clerk Summary • 2025‑08‑27</li><li>Agenda Packet • 2025‑08‑26</li></ul>`;
       }
@@ -336,6 +359,41 @@
       };
       reader.readAsText(file);
       e.target.value = '';
+    });
+
+    // ===== Settings =====
+    const settingsBtn = document.getElementById('settings-btn');
+    const settingsModal = document.getElementById('settings-modal');
+    const instructionsInput = document.getElementById('llm-instructions');
+    const settingsSave = document.getElementById('settings-save');
+    const settingsCancel = document.getElementById('settings-cancel');
+    const clearCacheBtn = document.getElementById('clear-cache');
+
+    settingsBtn.addEventListener('click', () => {
+      instructionsInput.value = localStorage.getItem('osg_instructions') || '';
+      settingsModal.classList.remove('hidden');
+    });
+
+    settingsCancel.addEventListener('click', () => {
+      settingsModal.classList.add('hidden');
+    });
+
+    settingsSave.addEventListener('click', () => {
+      localStorage.setItem('osg_instructions', instructionsInput.value.trim());
+      settingsModal.classList.add('hidden');
+    });
+
+    settingsModal.addEventListener('click', (e) => {
+      if(e.target === settingsModal) settingsModal.classList.add('hidden');
+    });
+
+    clearCacheBtn.addEventListener('click', async () => {
+      localStorage.clear();
+      if('caches' in window){
+        const keys = await caches.keys();
+        await Promise.all(keys.map(k => caches.delete(k)));
+      }
+      location.reload();
     });
 
     /* ===== Minimal self-tests (dev diagnostics) =====


### PR DESCRIPTION
## Summary
- add gear icon in header to open new settings modal
- allow entering persistent LLM special instructions and optional cache clearing
- wire instruction storage into mock response flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a6892d0833290f40b4f9af806ff