### PR TITLE
Wire up OpenAI chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
     // Composer submit (local mock; replace with vector search call if you attach one)
     document.getElementById('composer').addEventListener('submit', submitComposer);
 
-    function submitComposer(e){
+    async function submitComposer(e){
       if(e) e.preventDefault();
       const text = promptEl.value.trim();
       if(!text) return;
@@ -285,14 +285,52 @@
       promptEl.value = '';
       promptEl.focus();
 
-      // Fake thinking then respond based on mode
       const mode = document.querySelector('input[name="mode"]:checked').value;
-      const reply = mockAnswer(text, mode, instructions);
-      setTimeout(() => {
+
+      // If no API key, fall back to mock answers
+      if(!OPENAI_API_KEY){
+        const reply = mockAnswer(text, mode, instructions);
+        setTimeout(() => {
+          pushMessage({role:'assistant', content:reply});
+          renderBubble('assistant', reply, true);
+          window.scrollTo({top: document.body.scrollHeight, behavior: 'smooth'});
+        }, 300);
+        return;
+      }
+
+      // Show placeholder while fetching
+      const placeholder = renderBubble('assistant', '…');
+      const body = placeholder.querySelector('div');
+      window.scrollTo({top: document.body.scrollHeight, behavior: 'smooth'});
+
+      try{
+        const history = chats.map(({role, content}) => ({role, content}));
+        const messages = [...history];
+
+        // Apply mode + custom instructions
+        let modeInstruction = '';
+        if(mode === 'detailed') modeInstruction = 'Provide a detailed answer.';
+        else if(mode === 'sources_only') modeInstruction = 'Only list relevant sources. Do not answer the question.';
+        else modeInstruction = 'Provide a concise answer.';
+        if(modeInstruction) messages.unshift({role:'system', content: modeInstruction});
+        if(instructions) messages.unshift({role:'system', content: instructions});
+
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method:'POST',
+          headers:{
+            'Content-Type':'application/json',
+            'Authorization':`Bearer ${OPENAI_API_KEY}`
+          },
+          body: JSON.stringify({model:'gpt-4o-mini', messages})
+        });
+        const data = await res.json();
+        const reply = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content ? data.choices[0].message.content.trim() : '';
+
         pushMessage({role:'assistant', content:reply});
-        renderBubble('assistant', reply, true);
-        window.scrollTo({top: document.body.scrollHeight, behavior: 'smooth'});
-      }, 300);
+        body.textContent = reply || '[No response]';
+      }catch(err){
+        body.textContent = `Error: ${err.message}`;
+      }
     }
 
     function pushMessage(m){
@@ -328,6 +366,7 @@
       }
 
       chat.appendChild(a);
+      return a;
     }
 
     function mockAnswer(q, mode, instructions){

--- a/test-openai.js
+++ b/test-openai.js
@@ -4,15 +4,22 @@ if(!apiKey){
   console.error('Missing OPENAI_API_KEY');
   process.exit(1);
 }
-fetch('https://api.openai.com/v1/models', {
+
+fetch('https://api.openai.com/v1/chat/completions', {
+  method: 'POST',
   headers: {
+    'Content-Type': 'application/json',
     'Authorization': `Bearer ${apiKey}`
-  }
+  },
+  body: JSON.stringify({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'Say hello from Node' }]
+  })
 })
   .then(r => r.json())
   .then(d => {
-    const count = Array.isArray(d.data) ? d.data.length : 0;
-    console.log('Model count:', count);
+    const text = d.choices && d.choices[0] && d.choices[0].message && d.choices[0].message.content ? d.choices[0].message.content.trim() : '';
+    console.log('Response:', text);
   })
   .catch(e => {
     console.error('Error talking to OpenAI:', e);


### PR DESCRIPTION
## Summary
- Connect chat UI to OpenAI's chat completions API using `OPENAI_API_KEY`.
- Allow dynamic assistant bubble updates and add fallback mock responses when no key is provided.
- Update Node test script to send a sample chat request.

## Testing
- `node test-openai.js` *(fails: Error talking to OpenAI: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d78dec88332a7b067534b58cbfb