### PR TITLE
feat: call OpenAI directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,8 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
+    import { hasAPIKey, getStarters, sendChat } from './openai-service.js';
     /* ===== PWA manifest (no extra file) ===== */
     (function attachManifest(){
       const manifest = {
@@ -215,85 +216,27 @@
     const nlForm = document.getElementById('newsletter');
     const nlMsg  = document.getElementById('nl-msg');
 
-    // Cloud Function proxy for OpenAI requests
-    const PROXY_URL = 'https://openai-proxy-810345357173.us-west1.run.app';
-
     async function loadStarters(){
-      if (chats.length !== 0) return;
+      if(chats.length !== 0 || !hasAPIKey()) return;
       try {
-        console.log("[loadStarters] sending request to", PROXY_URL);
-    
-        const body = {
-          model: "gpt-4o-mini",
-          input: "List four short example questions a citizen might ask about local government data."
-        };
-        console.log("[loadStarters] request body:", body);
-    
-        const res = await fetch(PROXY_URL, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json"
-          },
-          body: JSON.stringify(body)
-        });
-    
-        console.log("[loadStarters] raw response object:", res);
-    
-        // log status + headers
-        console.log("[loadStarters] status:", res.status, res.statusText);
-        res.headers.forEach((v, k) => console.log("[loadStarters] header:", k, "=", v));
-    
-        let dataText;
-        try {
-          dataText = await res.text(); // capture raw body first
-          console.log("[loadStarters] raw response text:", dataText);
-        } catch (e) {
-          console.error("[loadStarters] error reading response text:", e);
-        }
-    
-        let data = {};
-        try {
-          data = JSON.parse(dataText);
-        } catch (e) {
-          console.error("[loadStarters] error parsing JSON:", e);
-        }
-    
-        console.log("[loadStarters] parsed JSON:", data);
-    
-        const text = data.output_text || "";
-        console.log("[loadStarters] output_text field:", text);
-    
-        const prompts = text
-          .split("\n")
-          .map(s => s.replace(/^[\s\d\-\*\.]+/, "").trim())
-          .filter(Boolean)
-          .slice(0, 4);
-    
-        console.log("[loadStarters] extracted prompts:", prompts);
-    
-        if (prompts.length) {
-          const box = starters.querySelector("div");
-          if (!box) {
-            console.error("[loadStarters] no div inside #starters found");
-            return;
-          }
-          box.innerHTML = "";
-          prompts.forEach(p => {
-            const b = document.createElement("button");
-            b.dataset.prompt = p;
-            b.className =
-              "chip bg-gradient-to-r from-[var(--osg-purple)]/20 via-[var(--osg-teal)]/20 to-[var(--osg-orange)]/20 border border-[var(--osg-orange)]/30 text-[var(--osg-dark)] px-3 py-1.5 text-sm hover:opacity-80";
-            b.textContent = p;
+        const prompts = await getStarters();
+        if(prompts.length){
+          const box = starters.querySelector('div');
+          if(!box) return;
+          box.innerHTML='';
+          prompts.forEach(p=>{
+            const b=document.createElement('button');
+            b.dataset.prompt=p;
+            b.className='chip bg-gradient-to-r from-[var(--osg-purple)]/20 via-[var(--osg-teal)]/20 to-[var(--osg-orange)]/20 border border-[var(--osg-orange)]/30 text-[var(--osg-dark)] px-3 py-1.5 text-sm hover:opacity-80';
+            b.textContent=p;
             box.appendChild(b);
           });
-        } else {
-          console.warn("[loadStarters] no prompts extracted from output_text");
         }
-      } catch (err) {
-        console.error("[loadStarters] unexpected exception:", err);
+      }catch(err){
+        console.error('loadStarters failed', err);
       }
     }
-loadStarters()
+    loadStarters();
 
     // Optional: Cloud Function endpoint for newsletter (leave blank to skip)
     const CF_ENDPOINT = '';
@@ -324,7 +267,7 @@ loadStarters()
       if (metaEnter) { e.preventDefault(); document.getElementById('send').click(); }
     });
 
-    // Composer submit (calls Cloud Function proxy)
+    // Composer submit (calls OpenAI directly)
     document.getElementById('composer').addEventListener('submit', submitComposer);
 
     async function submitComposer(e){
@@ -364,20 +307,10 @@ loadStarters()
         if(modeInstruction) messages.unshift({role:'system', content: modeInstruction});
         if(instructions) messages.unshift({role:'system', content: instructions});
 
-        const res = await fetch(PROXY_URL, {
-          method:'POST',
-          headers:{ 'Content-Type':'application/json' },
-          body: JSON.stringify({
-            model: 'gpt-4o-mini',
-            input: [
-              ...history.map(h => ({role: h.role, content: h.content})),
-              {role: "user", content: text}
-            ]
-          })
-        });
-
-        const data = await res.json();
-        const reply = data.output?.[0]?.content?.[0]?.text?.trim() || "";
+        const reply = await sendChat([
+          ...messages,
+          {role:'user', content:text}
+        ]);
         pushMessage({role:'assistant', content:reply});
         body.textContent = reply || '[No response]';
       }catch(err){

--- a/openai-service.js
+++ b/openai-service.js
@@ -1,0 +1,44 @@
+const OPENAI_API_KEY = (typeof process !== 'undefined' ? process.env.OPENAI_API_KEY : '')
+  || globalThis.OPENAI_API_KEY || '';
+
+export function hasAPIKey(){
+  return !!OPENAI_API_KEY;
+}
+
+export async function getStarters(){
+  if(!OPENAI_API_KEY) return [];
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      input: 'List four short example questions a citizen might ask about local government data.'
+    })
+  });
+  const data = await res.json();
+  const text = data.output_text || '';
+  return text
+    .split('\n')
+    .map(s => s.replace(/^[\s\d\-\*\.]+/, '').trim())
+    .filter(Boolean)
+    .slice(0,4);
+}
+
+export async function sendChat(messages){
+  if(!OPENAI_API_KEY) throw new Error('Missing OPENAI_API_KEY');
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({ model: 'gpt-4o-mini', messages })
+  });
+  const data = await res.json();
+  return data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
+    ? data.choices[0].message.content.trim()
+    : '';
+}


### PR DESCRIPTION
## Summary
- remove Google Cloud proxy and call OpenAI API directly
- extract OpenAI logic to openai-service module
- wire chat composer and starter prompts to new service

## Testing
- `node -e "import('./openai-service.js').then(m=>console.log('exports',Object.keys(m))).catch(e=>console.error(e))"`
- `node test-openai.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af78db08c483329fdba0d35b07665e