### PR TITLE
feat: update OpenAI integration to use CDN SDK and remote key

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
     const nlMsg  = document.getElementById('nl-msg');
 
     async function loadStarters(){
-      if(chats.length !== 0 || !hasAPIKey()) return;
+      if(chats.length !== 0 || !(await hasAPIKey())) return;
       try {
         const prompts = await getStarters();
         if(prompts.length){

--- a/test-openai.js
+++ b/test-openai.js
@@ -1,27 +1,32 @@
 #!/usr/bin/env node
-const apiKey = process.env.OPENAI_API_KEY;
-if(!apiKey){
-  console.error('Missing OPENAI_API_KEY');
-  process.exit(1);
+
+const API_KEY_URL = 'https://openai-proxy-810345357173.us-west1.run.app';
+
+async function main(){
+  const apiKey = (await fetch(API_KEY_URL).then(r => r.text())).trim();
+  if(!apiKey){
+    console.error('Missing API key');
+    process.exit(1);
+  }
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      input: 'Say hello from Node'
+    })
+  });
+
+  const data = await res.json();
+  const text = data.output_text || '';
+  console.log('Response:', text.trim());
 }
 
-fetch('https://api.openai.com/v1/chat/completions', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${apiKey}`
-  },
-  body: JSON.stringify({
-    model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say hello from Node' }]
-  })
-})
-  .then(r => r.json())
-  .then(d => {
-    const text = d.choices && d.choices[0] && d.choices[0].message && d.choices[0].message.content ? d.choices[0].message.content.trim() : '';
-    console.log('Response:', text);
-  })
-  .catch(e => {
-    console.error('Error talking to OpenAI:', e);
-    process.exit(1);
-  });
+main().catch(e => {
+  console.error('Error talking to OpenAI:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- load OpenAI SDK from CDN and fetch API key from remote proxy
- switch all calls to new `responses` API and use async key checks
- refresh Node test script to pull API key from proxy

## Testing
- `node test-openai.js` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af86082a548332a81587418596f72a